### PR TITLE
Fix _config.yml gem path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You have 3 options for installing the plugin:
 In your `_config.yml` file, add a new array with the key gems and the values of the gem names of the plugins you’d like to use. In this case:
 
 ```
-gems: [jekyll-timeago]
+gems: [jekyll/timeago]
 ```
 
 **Via Bundler**


### PR DESCRIPTION
The dash breaks it... Slash gives the correct path.
