### PR TITLE
Fix configuration parsing of `threshold` param in Jekyll

### DIFF
--- a/lib/jekyll-timeago/core.rb
+++ b/lib/jekyll-timeago/core.rb
@@ -25,7 +25,7 @@ module Jekyll
         from      = validate_date(from)
         to        = validate_date(to)
         depth     = validate_depth(@options[:depth] || @options["depth"])
-        threshold = validate_threshold(@options[:threshold])
+        threshold = validate_threshold(@options[:threshold] || @options["threshold"])
 
         time_ago_to_now(from, to, depth, threshold)
       end

--- a/spec/source/_config.yml
+++ b/spec/source/_config.yml
@@ -2,8 +2,8 @@ plugins:
   - jekyll-timeago
 
 jekyll_timeago:
-  depth: 1
-  threshold: 0.01
+  depth: 2
+  threshold: 0.05
   translations_path: "/_locales/*.yaml"
   default_locale: 'en'
   available_locales:


### PR DESCRIPTION
The threshold parameter doesn't work in Jekyll because YAML keys are parsed as strings, not symbols.

I thought it was working because the test was correct, but that was only because `depth` was set to 1 in the Jekyll test.