### PR TITLE
Replace "个月", which is Chinese, with the Japanese "ヵ月"

### DIFF
--- a/lib/locales/ja.yaml
+++ b/lib/locales/ja.yaml
@@ -12,7 +12,7 @@ ja:
   years_short: '%{count}年'
   months:
     one: '1ヶ月'
-    other: '%{count}个月'
+    other: '%{count}ヵ月'
   months_short: '%{count}月'
   weeks:
     one: '1週間'


### PR DESCRIPTION
Replace the Chinese term 个月 with the Japanese ヵ月 on`ja.yaml` for consistency.